### PR TITLE
releng - update aws oidc for new actions ssl thumbprint

### DIFF
--- a/functional-tests/aws-functional-tests.tf
+++ b/functional-tests/aws-functional-tests.tf
@@ -31,7 +31,7 @@ resource "aws_iam_role_policy_attachment" "ftest_power_user_access" {
 
 resource "aws_iam_openid_connect_provider" "github" {
   url             = "https://token.actions.githubusercontent.com"
-  thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
+  thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1", "1c58a3a8518e8759bf075b76b750d4f2df264fcd"]
   client_id_list  = ["sts.amazonaws.com"]
 }
 

--- a/github-aws-access/ci-publish-docs.tf
+++ b/github-aws-access/ci-publish-docs.tf
@@ -75,7 +75,7 @@ resource "aws_iam_policy" "ci_access" {
 
 resource "aws_iam_openid_connect_provider" "github" {
   url             = "https://token.actions.githubusercontent.com"
-  thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
+  thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1", "1c58a3a8518e8759bf075b76b750d4f2df264fcd"]
   client_id_list  = ["sts.amazonaws.com"]
 }
 


### PR DESCRIPTION

some actions fail, this is the update per the official
https://github.com/aws-actions/configure-aws-credentials

